### PR TITLE
fix compiling and a misspelling

### DIFF
--- a/interpreter_ops.c
+++ b/interpreter_ops.c
@@ -1355,12 +1355,12 @@ void r4300i_COP1_BCTL (void)
     }
 }
 /************************** COP1: S functions ************************/
-__inline void Float_RoundToInteger32( int32_t * Dest, float * Source )
+void Float_RoundToInteger32( int32_t * Dest, float * Source )
 {
     *Dest = (int32_t)*Source;
 }
 
-__inline void Float_RoundToInteger64( int64_t * Dest, float * Source )
+void Float_RoundToInteger64( int64_t * Dest, float * Source )
 {
     *Dest = (int64_t)*Source;
 }
@@ -1533,12 +1533,12 @@ void r4300i_COP1_S_CMP (void)
 }
 
 /************************** COP1: D functions ************************/
-__inline void Double_RoundToInteger32( int32_t * Dest, double * Source )
+void Double_RoundToInteger32( int32_t * Dest, double * Source )
 {
     *Dest = (int32_t)*Source;
 }
 
-__inline void Double_RoundToInteger64( int64_t * Dest, double * Source )
+void Double_RoundToInteger64( int64_t * Dest, double * Source )
 {
     *Dest = (int64_t)*Source;
 }

--- a/main.c
+++ b/main.c
@@ -182,7 +182,7 @@ void usage(char progName[])
     printf("\tThe output is written to filename.au\n\n");
 
     printf("\tOptions:\n");
-    printf("\t-o\t\t\t\t specifies output filename; you may use placeholders (e.g. \"%%game%% - %%title%%\", avialable placeholders listed below)\n");
+    printf("\t-o\t\t\t\t specifies output filename; you may use placeholders (e.g. \"%%game%% - %%title%%\", available placeholders listed below)\n");
     printf("\t-%c\t--%s\t changes sampling rate to a more standard value, rather than the odd values that games use\n",(char)long_options[5].val,long_options[5].name);
     printf("\t-%c NUM\t--%s NUM\t\t NUM specifies the fade type: 1 - Linear; 2 - Logarithmic; 3 - half of sinewave; default: no fading\n",(char)long_options[2].val,long_options[2].name);
 #ifdef FLAC_SUPPORT

--- a/recompiler_memory.c
+++ b/recompiler_memory.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <malloc.h>
 #include <memory.h>
+#include <signal.h>
 #include <sys/mman.h>
 
 #include "main.h"


### PR DESCRIPTION
`#include <signal.h>` (or `<sys/wait.h>`) was necessary for siginfo_t and the like. Removing `__inline` made ld link properly. After that it was able to compile for me.